### PR TITLE
Total should be an integer in results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,7 @@ class Service {
 
       this.objectify(countQuery, query)
 
-      return countQuery.then(count => count[0].total).then(executeQuery)
+      return countQuery.then(count => parseInt(count[0].total, 10)).then(executeQuery)
     }
 
     return executeQuery().catch(errorHandler)


### PR DESCRIPTION
Other feathers services and plugins expect total to be an integer (and sometimes test for things like `total === 0`). Objection.js seems to return a string in count queries (at least for the pg adapter).