### PR TITLE
Add $joinEager query param to fetch relations with JoinEagerAlgorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,12 @@
   "description": "A service plugin for ObjectionJS an ORM based on KnexJS",
   "version": "0.6.0",
   "homepage": "https://github.com/mcchrish/feathers-objection",
-  "keywords": [
-    "feathers",
-    "feathers-plugin",
-    "knex",
-    "objection",
-    "orm"
-  ],
+  "keywords": ["feathers", "feathers-plugin", "knex", "objection", "orm"],
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/mcchrish/feathers-objection/blob/master/LICENSE"
+      "url":
+        "https://github.com/mcchrish/feathers-objection/blob/master/LICENSE"
     }
   ],
   "repository": {
@@ -40,7 +35,7 @@
     "release:major": "npm version major && npm publish",
     "compile": "rm -rf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
-    "lint": "standard src/**/*.js test/**/*.js --config",
+    "lint": "standard --fix src/**/*.js test/**/*.js --config",
     "mocha": "mocha test/ --compilers js:babel-core/register --timeout 5000",
     "test": "npm run compile && npm run lint && npm run mocha",
     "example": "babel-node example/app"
@@ -79,9 +74,7 @@
       "transform-class-properties",
       "add-module-exports"
     ],
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "standard": {
     "parser": "babel-eslint"

--- a/src/index.js
+++ b/src/index.js
@@ -116,11 +116,7 @@ class Service {
       q = this.Model.query()
         .skipUndefined()
         .allowEager(this.allowedEager)
-        .select(
-          ...filters.$select.concat(
-            filters.$select.includes(this.id) ? [] : this.id
-          )
-        )
+        .select(...filters.$select.concat(this.id))
       if ($eager) {
         q.eager($eager, this.namedEagerFilters)
       } else if ($joinEager) {

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class Service {
    * @param parentKey
    */
   objectify (query, params, parentKey) {
-    Object.keys(params || {}).forEach((key) => {
+    Object.keys(params || {}).forEach(key => {
       const value = params[key]
 
       if (isPlainObject(value)) {
@@ -89,23 +89,47 @@ class Service {
 
   createQuery (paramsQuery = {}) {
     const { filters, query } = filter(paramsQuery)
-    let q = this.Model.query().skipUndefined()
+    let q = this.Model.query()
+      .skipUndefined()
       .allowEager(this.allowedEager)
 
     // $eager for objection eager queries
     let $eager
+    let $joinEager
+
     if (query && query.$eager) {
       $eager = query.$eager
       delete query.$eager
       q.eager($eager, this.namedEagerFilters)
     }
 
+    if (query && query.$joinEager) {
+      $joinEager = query.$joinEager
+      delete query.$joinEager
+      q
+        .eagerAlgorithm(this.Model.JoinEagerAlgorithm)
+        .eager($joinEager, this.namedEagerFilters)
+    }
+
     // $select uses a specific find syntax, so it has to come first.
     if (filters.$select) {
-      q = this.Model.query().skipUndefined()
+      q = this.Model.query()
+        .skipUndefined()
         .allowEager(this.allowedEager)
-        .select(...filters.$select.concat(this.id))
-        .eager($eager, this.namedEagerFilters)
+        .select(
+          ...filters.$select.concat(
+            filters.$select.includes(this.id) ? [] : this.id
+          )
+        )
+      if ($eager) {
+        q.eager($eager, this.namedEagerFilters)
+      } else if ($joinEager) {
+        q
+          .eagerAlgorithm(this.Model.JoinEagerAlgorithm)
+          .eager($joinEager, this.namedEagerFilters)
+      }
+
+      // .joinEager($joinEager, this.namedEagerFilters)
     }
 
     // apply eager filters if specified
@@ -169,11 +193,15 @@ class Service {
     }
 
     if (count) {
-      let countQuery = this.Model.query().skipUndefined().count(`${this.id} as total`)
+      let countQuery = this.Model.query()
+        .skipUndefined()
+        .count(`${this.id} as total`)
 
       this.objectify(countQuery, query)
 
-      return countQuery.then(count => parseInt(count[0].total, 10)).then(executeQuery)
+      return countQuery
+        .then(count => parseInt(count[0].total, 10))
+        .then(executeQuery)
     }
 
     return executeQuery().catch(errorHandler)
@@ -184,9 +212,12 @@ class Service {
    * @param params
    */
   find (params) {
-    const paginate = (params && typeof params.paginate !== 'undefined') ? params.paginate : this.paginate
-    const result = this._find(params, !!paginate.default,
-      query => filter(query, paginate)
+    const paginate =
+      params && typeof params.paginate !== 'undefined'
+        ? params.paginate
+        : this.paginate
+    const result = this._find(params, !!paginate.default, query =>
+      filter(query, paginate)
     )
 
     if (!paginate.default) {
@@ -201,13 +232,14 @@ class Service {
     query[this.id] = id
 
     return this._find(Object.assign({}, params, { query }))
-    .then(page => {
-      if (page.data.length !== 1) {
-        throw new errors.NotFound(`No record found for id '${id}'`)
-      }
+      .then(page => {
+        if (page.data.length !== 1) {
+          throw new errors.NotFound(`No record found for id '${id}'`)
+        }
 
-      return page.data[0]
-    }).catch(errorHandler)
+        return page.data[0]
+      })
+      .catch(errorHandler)
   }
 
   /**
@@ -220,10 +252,14 @@ class Service {
   }
 
   _create (data, params) {
-    return this.Model.query().insert(data, this.id).then(row => {
-      const id = typeof data[this.id] !== 'undefined' ? data[this.id] : row[this.id]
-      return this._get(id, params)
-    }).catch(errorHandler)
+    return this.Model.query()
+      .insert(data, this.id)
+      .then(row => {
+        const id =
+          typeof data[this.id] !== 'undefined' ? data[this.id] : row[this.id]
+        return this._get(id, params)
+      })
+      .catch(errorHandler)
   }
 
   /**
@@ -247,32 +283,39 @@ class Service {
    */
   update (id, data, params) {
     if (Array.isArray(data)) {
-      return Promise.reject('Not replacing multiple records. Did you mean `patch`?')
+      return Promise.reject(
+        'Not replacing multiple records. Did you mean `patch`?'
+      )
     }
 
     // NOTE (EK): First fetch the old record so
     // that we can fill any existing keys that the
     // client isn't updating with null;
-    return this._get(id, params).then(oldData => {
-      let newObject = {}
+    return this._get(id, params)
+      .then(oldData => {
+        let newObject = {}
 
-      for (var key of Object.keys(oldData)) {
-        if (data[key] === undefined) {
-          newObject[key] = null
-        } else {
-          newObject[key] = data[key]
+        for (var key of Object.keys(oldData)) {
+          if (data[key] === undefined) {
+            newObject[key] = null
+          } else {
+            newObject[key] = data[key]
+          }
         }
-      }
 
-      // NOTE (EK): Delete id field so we don't update it
-      delete newObject[this.id]
+        // NOTE (EK): Delete id field so we don't update it
+        delete newObject[this.id]
 
-      return this.Model.query().where(this.id, id).update(newObject).then(() => {
-        // NOTE (EK): Restore the id field so we can return it to the client
-        newObject[this.id] = id
-        return newObject
+        return this.Model.query()
+          .where(this.id, id)
+          .update(newObject)
+          .then(() => {
+            // NOTE (EK): Restore the id field so we can return it to the client
+            newObject[this.id] = id
+            return newObject
+          })
       })
-    }).catch(errorHandler)
+      .catch(errorHandler)
   }
 
   /**
@@ -290,8 +333,8 @@ class Service {
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
-    const ids = id === null ? this._find(params)
-      .then(mapIds) : Promise.resolve([ id ])
+    const ids =
+      id === null ? this._find(params).then(mapIds) : Promise.resolve([id])
 
     if (id !== null) {
       query[this.id] = id
@@ -303,32 +346,34 @@ class Service {
 
     delete data[this.id]
 
-    return ids.then(idList => {
-      // Create a new query that re-queries all ids that
-      // were originally changed
-      const findParams = Object.assign({}, params, {
-        query: {
-          [this.id]: { $in: idList },
-          $select: params.query && params.query.$select
-        }
-      })
-
-      return q.patch(data).then(() => {
-        return this._find(findParams).then(page => {
-          const items = page.data
-
-          if (id !== null) {
-            if (items.length === 1) {
-              return items[0]
-            } else {
-              throw new errors.NotFound(`No record found for id '${id}'`)
-            }
+    return ids
+      .then(idList => {
+        // Create a new query that re-queries all ids that
+        // were originally changed
+        const findParams = Object.assign({}, params, {
+          query: {
+            [this.id]: { $in: idList },
+            $select: params.query && params.query.$select
           }
+        })
 
-          return items
+        return q.patch(data).then(() => {
+          return this._find(findParams).then(page => {
+            const items = page.data
+
+            if (id !== null) {
+              if (items.length === 1) {
+                return items[0]
+              } else {
+                throw new errors.NotFound(`No record found for id '${id}'`)
+              }
+            }
+
+            return items
+          })
         })
       })
-    }).catch(errorHandler)
+      .catch(errorHandler)
   }
 
   /**
@@ -345,24 +390,26 @@ class Service {
       params.query[this.id] = id
     }
 
-    return this._find(params).then(page => {
-      const items = page.data
-      const query = this.Model.query()
+    return this._find(params)
+      .then(page => {
+        const items = page.data
+        const query = this.Model.query()
 
-      this.objectify(query, params.query)
+        this.objectify(query, params.query)
 
-      return query.delete().then(() => {
-        if (id !== null) {
-          if (items.length === 1) {
-            return items[0]
-          } else {
-            throw new errors.NotFound(`No record found for id '${id}'`)
+        return query.delete().then(() => {
+          if (id !== null) {
+            if (items.length === 1) {
+              return items[0]
+            } else {
+              throw new errors.NotFound(`No record found for id '${id}'`)
+            }
           }
-        }
 
-        return items
+          return items
+        })
       })
-    }).catch(errorHandler)
+      .catch(errorHandler)
   }
 }
 

--- a/test/company.js
+++ b/test/company.js
@@ -9,9 +9,9 @@ export default class Company extends Model {
     required: ['name'],
 
     properties: {
-      id: {type: 'integer'},
-      name: {type: 'string'},
-      ceo: {type: ['integer', 'null']}
+      id: { type: 'integer' },
+      name: { type: 'string' },
+      ceo: { type: ['integer', 'null'] }
     }
   }
 
@@ -23,6 +23,14 @@ export default class Company extends Model {
       join: {
         from: 'companies.ceo',
         to: 'people.id'
+      }
+    },
+    employees: {
+      relation: Model.HasManyRelation,
+      modelClass: path.join(__dirname, '/employee'),
+      join: {
+        from: 'companies.id',
+        to: 'employees.companyId'
       }
     }
   }

--- a/test/employee.js
+++ b/test/employee.js
@@ -1,0 +1,28 @@
+import { Model } from 'objection'
+
+export default class Employee extends Model {
+  static tableName = 'employees'
+  static jsonSchema = {
+    type: 'object',
+    required: ['name'],
+
+    properties: {
+      id: { type: 'integer' },
+      companyId: { type: 'integer' },
+      name: { type: 'string' }
+    }
+  }
+
+  static get relationMappings () {
+    return {
+      company: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: require('./company'),
+        join: {
+          from: 'employees.companyId',
+          to: 'companies.id'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi, this makes a quick fix for #9 

You can now use `$joinEager` param in the query object, and this relation will be eager loaded with SQL join, so you can actually filter based on related fields.

**NOTE:** At the moment it doesn't work too well with `$select`, because $select refers to fields in the Model table and joinEager will add all the related entities field so ambiguous name can occur.

This can however fixed easily by using the `modify` parameter in the relation, that allows to include specific fields for the related entity.


Pull request includes code, test, and added `--fix` to your eslint config so spaces and such are automatically fixed. For tests, I added a new `Employee` model that belongs to existing `Company`. That DB setup for tests could probably be extracted into a helper file, but I didn't want to move too many parts around. :)

What do you think? :)
