### PR TITLE
Fixed $eager and $joinEager to be treated as columns by count()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,15 @@ class Service {
    * @param parentKey
    */
   objectify (query, params, parentKey) {
+    // Delete $eager
+    if (params.$eager) {
+      delete params.$eager;
+    }
+
+    // Delete $joinEager
+    if (params.$joinEager) {
+      delete params.$joinEager;
+    }
     Object.keys(params || {}).forEach(key => {
       const value = params[key]
 


### PR DESCRIPTION
Fixes https://github.com/mcchrish/feathers-objection/issues/8 (tested)

Error resolved: `Method: find: select count("id") as "total" from "fbd"."businesses" where "$eager" = $1 - column "$eager" does not exist`