### PR TITLE
Added support for composite primary keys as `id`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-objection",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feathers-objection",
   "description": "A service plugin for ObjectionJS an ORM based on KnexJS",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "homepage": "https://github.com/mcchrish/feathers-objection",
   "keywords": [
     "feathers",

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class Service {
   }
 
   extractIds (id) {
-    if (typeof id === 'object') { return Object.values(id) }
+    if (typeof id === 'object') { return this.id.map(idKey => id[idKey]) }
     if (id[0] === '[' && id[id.length - 1] === ']') { return JSON.parse(id) }
     if (id[0] === '{' && id[id.length - 1] === '}') { return Object.values(JSON.parse(id)) }
 

--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,7 @@ class Service {
     if (count) {
       const idColumns = Array.isArray(this.id) ? this.id.map(idKey => `${this.Model.tableName}.${idKey}`) : [`${this.Model.tableName}.${this.id}`]
 
-      let countQuery = this.Model.query()
+      let countQuery = this._createQuery(params)
         .skipUndefined()
         .countDistinct({ total: idColumns })
 

--- a/src/index.js
+++ b/src/index.js
@@ -231,9 +231,11 @@ class Service {
     }
 
     if (count) {
+      const idColumns = Array.isArray(this.id) ? this.id.map(idKey => `${this.Model.tableName}.${idKey}`) : [`${this.Model.tableName}.${this.id}`]
+
       let countQuery = this.Model.query()
         .skipUndefined()
-        .count('* as total')
+        .countDistinct({ total: idColumns })
 
       this.objectify(countQuery, query)
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,9 +53,9 @@ class Service {
     return Proto.extend(obj, this)
   }
 
-  extractIdsFromString (id) {
+  extractIds (id) {
+    if (typeof id === 'object') { return Object.values(id) }
     if (id[0] === '[' && id[id.length - 1] === ']') { return JSON.parse(id) }
-
     if (id[0] === '{' && id[id.length - 1] === '}') { return Object.values(JSON.parse(id)) }
 
     return id.split(this.idSeparator)
@@ -69,7 +69,7 @@ class Service {
       let ids = id
 
       if (id && !Array.isArray(id)) {
-        ids = this.extractIdsFromString(id.toString())
+        ids = this.extractIds(id)
       }
 
       this.id.forEach((idKey, index) => {

--- a/src/index.js
+++ b/src/index.js
@@ -408,7 +408,13 @@ class Service {
 
     this.objectify(q, query)
 
-    delete data[this.id]
+    if (Array.isArray(this.id)) {
+      for (const idKey of this.id) {
+        delete data[idKey]
+      }
+    } else {
+      delete data[this.id]
+    }
 
     return ids
       .then(idList => {

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ class Service {
         }
       })
     } else {
-      query[this.id] = idList ? { $in: idList } : id
+      query[`${this.Model.tableName}.${this.id}`] = idList ? { $in: idList } : id
     }
 
     return query


### PR DESCRIPTION
When using DB tables with composite primary keys, there is no way to use the `id` argument to match or fail against a single unique record.

This PR adds support for composite primary keys by enabling a developer to set the `service.id` property to an array of strings and use the `id` argument to pass all composite keys' values of a record.

When calling a service method with the `id` argument, all primary keys are required to be passed if using composite primary keys.

Composite `id` values can be passed as:

- string with values separated by the new `service.idSeparator` property or using the default comma separator (order matter, recommended for REST)
- JSON array (order matter, recommended for internal service calls)
- JSON object (more readable, recommended for internal service calls)